### PR TITLE
 Add TravisCI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: go
+
+# Specify Go versions to test (".x" suffix means latest minor version, "tip" is
+# the latest development version)
+go:
+  - "1.9.x"
+  - "1.10.x"
+  - "1.11.x"
+  - tip
+
+# Allow failures on development version as they can happen due to third party
+# problems. Consider the build successful as soon as all other builds are
+# finished.
+matrix:
+  allow_failures:
+    - go: tip
+  fast_finish: true
+
+# Install all dependencies (including dependencies of tests) without installing
+# binaries.
+install:
+  - go get -d -t -v ./...
+
+# Check if gofmt or go vet report any errors then run all tests with the race
+# detector enabled.
+script:
+  - diff -u <(echo -n) <(gofmt -d .)
+  - go tool vet .
+  - go test -race -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,10 @@ matrix:
 install:
   - go get -d -t -v ./...
 
-# Check if gofmt or go vet report any errors then run all tests with the race
-# detector enabled.
+# Check if gofmt or go vet report any errors, run all tests with the race
+# detector enabled, then build all examples to make sure they still compile.
 script:
   - diff -u <(echo -n) <(gofmt -d .)
   - go tool vet .
   - go test -race -v ./...
+  - go build -v $(go list ./**/_example)

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,11 @@ matrix:
   allow_failures:
     - go: tip
   fast_finish: true
-  # Also build with enabled module support regardless of $GOPATH
+  # Also build with enabled module support on versions which support it
   include:
     - go: "1.11.x"
+      env: GO111MODULE=on
+    - go: tip
       env: GO111MODULE=on
 
 # Install all dependencies (including dependencies of tests) without installing

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,6 @@ script:
   - go tool vet .
   - go test -race -v ./...
   - go build -v $(go list ./**/_example)
+
+# Force lowercase import path
+go_import_path: github.com/justanotherorganization/justanotherbotkit

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ matrix:
   allow_failures:
     - go: tip
   fast_finish: true
+  # Also build with enabled module support regardless of $GOPATH
+  include:
+    - go: "1.11.x"
+      env: GO111MODULE=on
 
 # Install all dependencies (including dependencies of tests) without installing
 # binaries.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # justanotherbotkit
+
+[![Build Status](https://travis-ci.com/JustAnotherOrganization/justanotherbotkit.svg?branch=master)](https://travis-ci.com/JustAnotherOrganization/justanotherbotkit)
+
 go based utilities for chat bot infrastructure.


### PR DESCRIPTION
Added a configuration file and build badge for TravisCI which is a popular continuous integration service. It will run test for new commits with go 1.9, 1.10, 1.11 and the latest development version. Also checks if `gofmt` or `go vet` reports any possible improvements.

If you already have Travis set up for your account, just enable it for the repository. Otherwise follow the instructions on their site: https://docs.travis-ci.com/user/getting-started/#to-get-started-with-travis-ci

After merging, hopefully a new build will start automatically, but if not you can test the setup by adding a new commit or manually triggering a build on the `master` branch.

Fixes #14.