### PR TITLE
Fix build badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # justanotherbotkit
 
-[![Build Status](https://travis-ci.com/JustAnotherOrganization/justanotherbotkit.svg?branch=master)](https://travis-ci.com/JustAnotherOrganization/justanotherbotkit)
+[![Build Status](https://travis-ci.org/JustAnotherOrganization/justanotherbotkit.svg?branch=master)](https://travis-ci.org/JustAnotherOrganization/justanotherbotkit)
 
 go based utilities for chat bot infrastructure.


### PR DESCRIPTION
Originally I've added the expected build badge URL for TravisCI's .com domain as they started to merge their .com and .org infrastructure back in May, and I assumed that new project cannot be added for .org anymore. Looks like this assumption was wrong, so here's the fixed URL.